### PR TITLE
delete pre-generated host SSH keys

### DIFF
--- a/build-appliance
+++ b/build-appliance
@@ -265,8 +265,25 @@ INSTALL="\$INSTALL resolvconf"
 echo ">>>>>> INSTALL=\$INSTALL"
 apt-get -qq -y install \$INSTALL
 
-# delete pre-generated SSH keys
-rm /etc/ssh/ssh*key /etc/ssh/ssh*key.pub
+# prepare regenerating SSH keys on the very first reboot
+echo '[Unit]
+Description=Regenerate SSH host keys
+Before=ssh.service
+ConditionFileIsExecutable=/usr/bin/ssh-keygen
+
+[Service]
+Type=oneshot
+ExecStartPre=-/bin/dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096
+ExecStartPre=-/bin/sh -c "/bin/rm -f -v /etc/ssh/ssh_host_*_key*"
+ExecStart=/usr/bin/ssh-keygen -A -v
+ExecStartPost=/bin/systemctl disable regenerate_ssh_host_keys
+
+[Install]
+WantedBy=multi-user.target
+' > /etc/systemd/system/regenerate_ssh_host_keys.service
+chown root:root /etc/systemd/system/regenerate_ssh_host_keys.service
+# no reason to exec in chroot: systemctl daemon-reload
+systemctl enable regenerate_ssh_host_keys.service
 
 echo ">>>>>> add czertainly user"
 groupadd czertainly


### PR DESCRIPTION
fix of previous https://github.com/CZERTAINLY/CZERTAINLY-Appliance/pull/83/commits/abf00337dfc93fdff03c2317dd93bcb372061e31 which is not enought on Debian
closes #83 